### PR TITLE
Livestate name

### DIFF
--- a/alignak_backend/__init__.py
+++ b/alignak_backend/__init__.py
@@ -8,7 +8,7 @@
     This module is an Alignak REST backend
 """
 # Application version and manifest
-VERSION = (0, 4, 3)
+VERSION = (0, 4, 4, 'beta')
 
 __application__ = u"Alignak_Backend"
 __short_version__ = '.'.join((str(each) for each in VERSION[:2]))

--- a/alignak_backend/livestate.py
+++ b/alignak_backend/livestate.py
@@ -57,9 +57,11 @@ class Livestate(object):
                     '_realm': item['realm'], 'name': item['name']}
             if item['initial_state'] == 'd':
                 data['state'] = 'DOWN'
+                data['state_id'] = 1
                 data['last_state'] = 'DOWN'
             elif item['initial_state'] == 'u':
                 data['state'] = 'UNREACHABLE'
+                data['state_id'] = 2
                 data['last_state'] = 'UNREACHABLE'
             post_internal("livestate", data)
 
@@ -99,12 +101,15 @@ class Livestate(object):
                     'name': host_info['name'] + '/' + item['name']}
             if item['initial_state'] == 'w':
                 data['state'] = 'WARNING'
+                data['state_id'] = 1
                 data['last_state'] = 'WARNING'
             elif item['initial_state'] == 'c':
                 data['state'] = 'CRITICAL'
+                data['state_id'] = 2
                 data['last_state'] = 'CRITICAL'
             elif item['initial_state'] == 'u':
                 data['state'] = 'UNKNOWN'
+                data['state_id'] = 3
                 data['last_state'] = 'UNKNOWN'
             post_internal("livestate", data)
 

--- a/alignak_backend/livestate.py
+++ b/alignak_backend/livestate.py
@@ -54,7 +54,7 @@ class Livestate(object):
                     'last_state': 'UP', 'last_state_type': 'HARD', 'output': '',
                     'long_output': '', 'perf_data': '', 'type': 'host',
                     'business_impact': item['business_impact'], 'display_name_host': name,
-                    '_realm': item['realm']}
+                    '_realm': item['realm'], 'name': item['name']}
             if item['initial_state'] == 'd':
                 data['state'] = 'DOWN'
                 data['last_state'] = 'DOWN'
@@ -95,7 +95,8 @@ class Livestate(object):
                     'last_state': 'OK', 'last_state_type': 'HARD', 'output': '',
                     'long_output': '', 'perf_data': '', 'type': 'service',
                     'business_impact': item['business_impact'], 'display_name_service': name,
-                    'display_name_host': name_h, '_realm': item['_realm']}
+                    'display_name_host': name_h, '_realm': item['_realm'],
+                    'name': host_info['name'] + '/' + item['name']}
             if item['initial_state'] == 'w':
                 data['state'] = 'WARNING'
                 data['last_state'] = 'WARNING'

--- a/alignak_backend/models/contact.py
+++ b/alignak_backend/models/contact.py
@@ -47,8 +47,8 @@ def get_schema():
                 'regex': '^[^`~!$%^&*"|\'<>?,()=]+$'
             },
             'customs': {
-                'type': 'list',
-                'default': []
+                'type': 'dict',
+                'default': {}
             },
             'definition_order': {
                 'type': 'integer',

--- a/alignak_backend/models/host.py
+++ b/alignak_backend/models/host.py
@@ -59,8 +59,8 @@ def get_schema():
                 'dependencies': ['check_command']
             },
             'customs': {
-                'type': 'list',
-                'default': []
+                'type': 'dict',
+                'default': {}
             },
             'definition_order': {
                 'type': 'integer',

--- a/alignak_backend/models/livestate.py
+++ b/alignak_backend/models/livestate.py
@@ -24,6 +24,11 @@ def get_schema():
     """
     return {
         'schema': {
+            'name': {
+                'type': 'string',
+                'default': '',
+                'required': True
+            },
             'service_description': {
                 'type': 'objectid',
                 'data_relation': {

--- a/alignak_backend/models/service.py
+++ b/alignak_backend/models/service.py
@@ -58,8 +58,8 @@ def get_schema():
                 'dependencies': ['host_name', 'check_command']
             },
             'customs': {
-                'type': 'list',
-                'default': []
+                'type': 'dict',
+                'default': {}
             },
             'definition_order': {
                 'type': 'integer',


### PR DESCRIPTION
Prepare a new version 0.4.4
-----
Add the name field in the livestate: #38 
Fixes #50 : state_id initialization
`customs` field for host, service and contact is a dictionary (not a list)