### PR TITLE
History and actions change

### DIFF
--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -241,7 +241,7 @@ def after_insert_logcheckresult(items):
             'user': None,
             'type': 'check.result',
             'message': '',
-            'check_result': item['_id']
+            'logcheckresult': item['_id']
         }
         post_internal("history", data, True)
         # print("Created new history for check result: %s" % data)

--- a/alignak_backend/models/actionacknowledge.py
+++ b/alignak_backend/models/actionacknowledge.py
@@ -79,8 +79,7 @@ def get_schema():
                 'data_relation': {
                     'resource': 'realm',
                     'embeddable': True
-                },
-                'required': True,
+                }
             },
             '_sub_realm': {
                 'type': 'boolean',

--- a/alignak_backend/models/actiondowntime.py
+++ b/alignak_backend/models/actiondowntime.py
@@ -93,8 +93,7 @@ def get_schema():
                 'data_relation': {
                     'resource': 'realm',
                     'embeddable': True
-                },
-                'required': True,
+                }
             },
             '_sub_realm': {
                 'type': 'boolean',

--- a/alignak_backend/models/actionforcecheck.py
+++ b/alignak_backend/models/actionforcecheck.py
@@ -62,8 +62,7 @@ def get_schema():
                 'data_relation': {
                     'resource': 'realm',
                     'embeddable': True
-                },
-                'required': True,
+                }
             },
             '_sub_realm': {
                 'type': 'boolean',

--- a/alignak_backend/models/history.py
+++ b/alignak_backend/models/history.py
@@ -80,7 +80,7 @@ def get_schema():
                 'type': 'string',
                 'default': ''
             },
-            'check_result': {
+            'logcheckresult': {
                 'type': 'objectid',
                 'data_relation': {
                     'resource': 'logcheckresult',

--- a/test/test_logcheckresult.py
+++ b/test/test_logcheckresult.py
@@ -204,4 +204,4 @@ class TestActions(unittest2.TestCase):
         self.assertEqual(re[0]['service'], None)
         self.assertEqual(re[0]['type'], "check.result")
         self.assertEqual(re[0]['message'], "")
-        self.assertEqual(re[0]['check_result'], check_id)
+        self.assertEqual(re[0]['logcheckresult'], check_id)


### PR DESCRIPTION
History field name changed to be more consistent

Actions do not require `_realm` field to be present because the backend uses the host _realm