### PR TITLE
Allow null host in service model (for templates)

### DIFF
--- a/alignak_backend/models/service.py
+++ b/alignak_backend/models/service.py
@@ -49,6 +49,7 @@ def get_schema():
                     'resource': 'host',
                     'embeddable': True
                 },
+                'nullable': True
             },
             'hostgroups': {
                 'type': 'string',


### PR DESCRIPTION
In the service templates, no host is defined. as of it, host field must be nullable