### PR TITLE
#101: Manage usergroups like hostgroups (level, parent, ...)

### DIFF
--- a/alignak_backend/models/usergroup.py
+++ b/alignak_backend/models/usergroup.py
@@ -46,6 +46,28 @@ def get_schema():
                 'type': 'string',
                 'default': '',
             },
+            '_level': {
+                'type': 'integer',
+                'default': 0,
+            },
+            '_parent': {
+                'type': 'objectid',
+                'data_relation': {
+                    'resource': 'usergroup',
+                    'embeddable': True
+                },
+            },
+            '_tree_parents': {
+                'type': 'list',
+                'schema': {
+                    'type': 'objectid',
+                    'data_relation': {
+                        'resource': 'usergroup',
+                        'embeddable': True,
+                    }
+                },
+                'default': []
+            },
             'usergroups': {
                 'type': 'list',
                 'schema': {


### PR DESCRIPTION
Add _level, _parent, ... fields in the `usergroup` data model
Add backend hooks to manage those new fields
Add a new default "All users' group