### PR TITLE
WiP: Return livestate fields for host/service when it exists

### DIFF
--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -249,6 +249,7 @@ def on_return_host(response):
                 if k not in ['_id', '_etag', '_created', '_updated', '_realm', 'name', 'host']:
                     item[k] = ls[k]
 
+
 def on_return_service(response):
     """
     Hook before getting some hosts
@@ -267,6 +268,7 @@ def on_return_service(response):
             for k in ls:
                 if k not in ['_id', '_etag', '_created', '_updated', '_realm', 'name', 'service']:
                     item[k] = ls[k]
+
 
 # Log checks results
 def pre_logcheckresult_post(items):

--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -245,9 +245,7 @@ def on_return_host(response):
             if not ls:
                 continue
 
-            for k in ls:
-                if k not in ['_id', '_etag', '_created', '_updated', '_realm', 'name', 'host']:
-                    item[k] = ls[k]
+            item['livestate'] = ls
 
 
 def on_return_service(response):
@@ -265,9 +263,7 @@ def on_return_service(response):
             if not ls:
                 continue
 
-            for k in ls:
-                if k not in ['_id', '_etag', '_created', '_updated', '_realm', 'name', 'service']:
-                    item[k] = ls[k]
+            item['livestate'] = ls
 
 
 # Log checks results

--- a/alignak_backend/models/host.py
+++ b/alignak_backend/models/host.py
@@ -19,6 +19,10 @@ def get_schema():
     """
     Schema structure of this resource
 
+    When getting this resource in the backend, the application tries to find an associated
+    livestate item. If one is found, all the fields (except special ones) of the found livestate
+    are returned with this model fields.
+
     :return: schema dictionary
     :rtype: dict
     """

--- a/alignak_backend/models/service.py
+++ b/alignak_backend/models/service.py
@@ -19,6 +19,10 @@ def get_schema():
     """
     Schema structure of this resource
 
+    When getting this resource in the backend, the application tries to find an associated
+    livestate item. If one is found, all the fields (except special ones) of the found livestate
+    are returned with this model fields.
+
     :return: schema dictionary
     :rtype: dict
     """


### PR DESCRIPTION
When getting an host or service, the backend application searches for an associated livestate and returns all livestate fields (except specific ones ...) with the host/service fields.