### PR TITLE
Fix #280 - log in its own directory

### DIFF
--- a/alignak_backend/__init__.py
+++ b/alignak_backend/__init__.py
@@ -8,7 +8,7 @@
     This module is an Alignak REST backend
 """
 # Application version and manifest
-VERSION = (0, 8, 10)
+VERSION = (0, 8, 11)
 
 __application__ = u"Alignak_Backend"
 __short_version__ = '.'.join((str(each) for each in VERSION[:2]))

--- a/etc/uwsgi.ini
+++ b/etc/uwsgi.ini
@@ -13,8 +13,8 @@ enable-threads = true
 processes = 4
 
 # Log activity in those files
-req-logger = file:/usr/local/var/log/alignak/backend-access.log
-logger = file:/usr/local/var/log/alignak/backend-error.log
+req-logger = file:/usr/local/var/log/alignak-backend/backend-access.log
+logger = file:/usr/local/var/log/alignak-backend/backend-error.log
 
 # Report memory activity to the stats
 memory-report = true

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ package = import_module('alignak_backend')
 
 data_files = [('etc/alignak-backend', ['etc/settings.json', 'etc/uwsgi.ini']),
               ('bin', ['bin/alignak-backend-uwsgi']),
-              ('var/log/alignak', [])]
+              ('var/log/alignak-backend', [])]
 if 'bsd' in sys.platform or 'dragonfly' in sys.platform:
     data_files.append(('etc/rc.d', ['bin/rc.d/alignak-backend']))
 


### PR DESCRIPTION
Log in */usr/local/var/log/alignak-backend* and not */usr/local/var/log/alignak-backend*, else upgrading with pip breaks the log directory
Set version as 0.8.11