### PR TITLE
Graphite metrics with leading / in name

### DIFF
--- a/alignak_backend/timeseries.py
+++ b/alignak_backend/timeseries.py
@@ -81,7 +81,7 @@ class Timeseries(object):
             # Sanitize field name for TSDB (Graphite or Influx):
             my_target = fields['name'].strip()
             if my_target.startswith('/'):
-                my_target = my_target[1:]
+                my_target = '_' + my_target[1:]
             # + becomes a _
             my_target = my_target.replace("+", "_")
             # / becomes a -

--- a/alignak_backend/timeseries.py
+++ b/alignak_backend/timeseries.py
@@ -79,8 +79,11 @@ class Timeseries(object):
                 fields['name'] = m.group(1)
 
             # Sanitize field name for TSDB (Graphite or Influx):
+            my_target = fields['name'].strip()
+            if my_target.startswith('/'):
+                my_target = my_target[1:]
             # + becomes a _
-            my_target = fields['name'].replace("+", "_")
+            my_target = my_target.replace("+", "_")
             # / becomes a -
             my_target = my_target.replace("/", "-")
             # space becomes a _

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -264,6 +264,59 @@ class TestTimeseries(unittest2.TestCase):
         }
         self.assertItemsEqual(reference['data'], ret['data'])
 
+    def test_prepare_data_nrpe_disk(self):
+        """Prepare timeseries from an NRPE disk
+
+        :return: None
+        """
+        item = {
+            'host': 'srv001',
+            'service': 'check_xxx',
+            'state': 'OK',
+            'state_type': 'HARD',
+            'state_id': 0,
+            'acknowledged': False,
+            'last_check': int(time.time()),
+            'last_state': 'OK',
+            'output': 'DISK OK - free space: /tmp 2323 MB (33% inode=64%);',
+            'long_output': '',
+            # Note the leading space and /
+            'perf_data': " /tmp=4660MB;5904;6642;0;7381",
+            '_realm': 'All.Propieres'
+        }
+
+        ret = Timeseries.prepare_data(item)
+        reference = {
+            'data': [
+                {
+                    'name': 'tmp',
+                    'value': 4660,
+                    'uom': 'MB'
+                },
+                {
+                    'name': 'tmp_critical',
+                    'value': 6642,
+                    'uom': 'MB'
+                },
+                {
+                    'name': 'tmp_warning',
+                    'value': 5904,
+                    'uom': 'MB'
+                },
+                {
+                    'name': 'tmp_min',
+                    'value': 0,
+                    'uom': 'MB'
+                },
+                {
+                    'name': 'tmp_max',
+                    'value': 7381,
+                    'uom': 'MB'
+                },
+            ]
+        }
+        self.assertItemsEqual(reference['data'], ret['data'])
+
     def test_prepare_special_formatted(self):
         """
         Prepare timeseries from a special perfdata, with

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -264,11 +264,12 @@ class TestTimeseries(unittest2.TestCase):
         }
         self.assertItemsEqual(reference['data'], ret['data'])
 
-    def test_prepare_data_nrpe_disk(self):
+    def test_prepare_data_nrpe_checks(self):
         """Prepare timeseries from an NRPE disk
 
         :return: None
         """
+        # Nnrpe check_disk
         item = {
             'host': 'srv001',
             'service': 'check_xxx',
@@ -289,28 +290,77 @@ class TestTimeseries(unittest2.TestCase):
         reference = {
             'data': [
                 {
-                    'name': 'tmp',
+                    'name': '_tmp',
                     'value': 4660,
                     'uom': 'MB'
                 },
                 {
-                    'name': 'tmp_critical',
+                    'name': '_tmp_critical',
                     'value': 6642,
                     'uom': 'MB'
                 },
                 {
-                    'name': 'tmp_warning',
+                    'name': '_tmp_warning',
                     'value': 5904,
                     'uom': 'MB'
                 },
                 {
-                    'name': 'tmp_min',
+                    'name': '_tmp_min',
                     'value': 0,
                     'uom': 'MB'
                 },
                 {
-                    'name': 'tmp_max',
+                    'name': '_tmp_max',
                     'value': 7381,
+                    'uom': 'MB'
+                },
+            ]
+        }
+        self.assertItemsEqual(reference['data'], ret['data'])
+
+        # Nnrpe check_root
+        item = {
+            'host': 'srv001',
+            'service': 'check_root',
+            'state': 'OK',
+            'state_type': 'HARD',
+            'state_id': 0,
+            'acknowledged': False,
+            'last_check': int(time.time()),
+            'last_state': 'OK',
+            'output': 'DISK OK - free space: / 6468 MB (82% inode=89%);',
+            'long_output': '',
+            # Note the leading space and /
+            'perf_data': " /=1403MB;6653;7485;0;8317",
+            '_realm': 'All.Propieres'
+        }
+
+        ret = Timeseries.prepare_data(item)
+        reference = {
+            'data': [
+                {
+                    'name': '_',
+                    'value': 1403,
+                    'uom': 'MB'
+                },
+                {
+                    'name': '__critical',
+                    'value': 7485,
+                    'uom': 'MB'
+                },
+                {
+                    'name': '__warning',
+                    'value': 6653,
+                    'uom': 'MB'
+                },
+                {
+                    'name': '__min',
+                    'value': 0,
+                    'uom': 'MB'
+                },
+                {
+                    'name': '__max',
+                    'value': 8317,
                     'uom': 'MB'
                 },
             ]


### PR DESCRIPTION
Fixes #299: remove leading slash in metrics name rather then replacing with dash