### PR TITLE
Set a message content in the history when posting a logcheckresult

### DIFF
--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -323,6 +323,9 @@ def after_insert_logcheckresult(items):
     """
     for dummy, item in enumerate(items):
         # Create an history event for the new forcecheck
+        message = "%s[%s] (%s/%s): %s" % (item['state'], item['state_type'],
+                                          item['acknowledged'], item['downtimed'],
+                                          item['output'])
         data = {
             'host': item['host'],
             'host_name': item['host_name'],
@@ -330,7 +333,7 @@ def after_insert_logcheckresult(items):
             'service_name': item['service_name'],
             'user': None,
             'type': 'check.result',
-            'message': '',
+            'message': message,
             'logcheckresult': item['_id']
         }
         post_internal("history", data, True)

--- a/test/test_logcheckresult.py
+++ b/test/test_logcheckresult.py
@@ -218,7 +218,7 @@ class TestActions(unittest2.TestCase):
         self.assertEqual(re[0]['service'], None)
         self.assertEqual(re[0]['service_name'], '')
         self.assertEqual(re[0]['type'], "check.result")
-        self.assertEqual(re[0]['message'], "")
+        self.assertEqual(re[0]['message'], "UP[HARD] (False/False): Check output")
         self.assertEqual(re[0]['logcheckresult'], check_id)
 
         # -------------------------------------------
@@ -277,5 +277,5 @@ class TestActions(unittest2.TestCase):
         self.assertEqual(re[1]['service'], rs[0]['_id'])
         self.assertEqual(re[1]['service_name'], rs[0]['name'])
         self.assertEqual(re[1]['type'], "check.result")
-        self.assertEqual(re[1]['message'], "")
+        self.assertEqual(re[1]['message'], "UP[HARD] (False/False): Check output")
         self.assertEqual(re[1]['logcheckresult'], check_id)


### PR DESCRIPTION
Closes #303: add a message to the history when posting a logcheckresult