### PR TITLE
Alignak endpoint, update

### DIFF
--- a/alignak_backend/__init__.py
+++ b/alignak_backend/__init__.py
@@ -8,7 +8,7 @@
     This module is an Alignak REST backend
 """
 # Application version and manifest
-VERSION = (0, 8, 18)
+VERSION = (0, 8, 19)
 
 __application__ = u"Alignak_Backend"
 __short_version__ = '.'.join((str(each) for each in VERSION[:2]))

--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -1173,6 +1173,28 @@ def after_delete_resource_realm():
     g.updateRealm = False
 
 
+# Alignak
+def pre_alignak_patch(updates, original):
+    # pylint: disable=unused-argument
+    """Hook before updating an alignak element.
+
+    When updating an alignak, if only the running data are updated, do not change the
+    _updated field.
+
+    :param updates: list of alignak fields to update
+    :type updates: dict
+    :param original: list of original fields
+    :type original: dict
+    :return: None
+    """
+    for key in updates:
+        if key not in ['_updated', 'last_alive', 'last_command_check', 'last_log_rotation']:
+            break
+    else:
+        # Only the running fields were updated, do not change _updated field
+        del updates['_updated']
+
+
 # Hosts/ services
 def pre_host_patch(updates, original):
     """
@@ -1798,6 +1820,7 @@ app.on_update_hostgroup += pre_hostgroup_patch
 app.on_update_servicegroup += pre_servicegroup_patch
 app.on_insert_graphite += pre_timeseries_post
 app.on_insert_influxdb += pre_timeseries_post
+app.on_update_alignak += pre_alignak_patch
 # check right on submit actions
 app.on_pre_POST_actionacknowledge += pre_post_action_right
 app.on_pre_POST_actiondowntime += pre_post_action_right

--- a/test/test_alignak.py
+++ b/test/test_alignak.py
@@ -157,3 +157,39 @@ class TestAlignak(unittest2.TestCase):
                                  auth=self.auth)
         resp = response.json()
         self.assertEqual('OK', resp['_status'], resp)
+        _id = resp['_id']
+        _etag = resp['_etag']
+        _updated = resp['_updated']
+
+        # Only update some fields, with a little delay...
+        time.sleep(1)
+        headers['If-Match'] = _etag
+        data = {
+            'name': 'my_alignak',
+            'alias': 'New alias',
+            'last_alive': 123456789,
+            'last_command_check': 123456789,
+            'last_log_rotation': 123456789
+        }
+        response = requests.patch(self.endpoint + '/alignak/%s' % _id, json=data,
+                                  headers=headers, auth=self.auth)
+        resp = response.json()
+        self.assertEqual('OK', resp['_status'], resp)
+        assert _updated != resp['_updated']
+        _id = resp['_id']
+        _etag = resp['_etag']
+        _updated = resp['_updated']
+
+        # Only update some live running fields, with a little delay...
+        time.sleep(1)
+        headers['If-Match'] = _etag
+        data = {
+            'last_alive': 123456789,
+            'last_command_check': 123456789,
+            'last_log_rotation': 123456789
+        }
+        response = requests.patch(self.endpoint + '/alignak/%s' % _id, json=data,
+                                  headers=headers, auth=self.auth)
+        resp = response.json()
+        self.assertEqual('OK', resp['_status'], resp)
+        assert _updated == resp['_updated']


### PR DESCRIPTION
Do not update the _updated field if only running alignak fields are updated. This will allow to include the alignak endpoint in the monitored resources for reloading the configuration.