### PR TITLE
Set the _parent property to a default None value (for realms and groups)

### DIFF
--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -784,7 +784,7 @@ def pre_hostgroup_post(items):
     hgs_drv = current_app.data.driver.db['hostgroup']
     for dummy, item in enumerate(items):
         # Default parent
-        if '_parent' not in item:
+        if '_parent' not in item or not item['_parent']:
             # Use default hostgroup as a parent
             def_hg = hgs_drv.find_one({'name': 'All'})
             if def_hg:
@@ -843,7 +843,7 @@ def pre_servicegroup_post(items):
     sgs_drv = current_app.data.driver.db['servicegroup']
     for dummy, item in enumerate(items):
         # Default parent
-        if '_parent' not in item:
+        if '_parent' not in item or not item['_parent']:
             # Use default servicegroup as a parent
             def_sg = sgs_drv.find_one({'name': 'All'})
             if def_sg:
@@ -902,7 +902,7 @@ def pre_usergroup_post(items):
     ugs_drv = current_app.data.driver.db['usergroup']
     for dummy, item in enumerate(items):
         # Default parent
-        if '_parent' not in item:
+        if '_parent' not in item or not item['_parent']:
             # Use default usergroup as a parent
             def_ug = ugs_drv.find_one({'name': 'All'})
             if def_ug:
@@ -994,7 +994,7 @@ def pre_realm_post(items):
     realmsdrv = current_app.data.driver.db['realm']
     for dummy, item in enumerate(items):
         # Default parent
-        if '_parent' not in item:
+        if '_parent' not in item or not item['_parent']:
             # Use default realm as a parent
             dr = realmsdrv.find_one({'name': 'All'})
             item['_parent'] = dr['_id']

--- a/alignak_backend/models/hostgroup.py
+++ b/alignak_backend/models/hostgroup.py
@@ -131,6 +131,8 @@ def get_schema():
                     'resource': 'hostgroup',
                     'embeddable': True
                 },
+                'nullable': True,
+                'default': None
             },
             '_tree_parents': {
                 "title": "Parents",

--- a/alignak_backend/models/realm.py
+++ b/alignak_backend/models/realm.py
@@ -139,6 +139,7 @@ def get_schema():
                     'resource': 'realm',
                     'embeddable': True
                 },
+                'default': None
             },
             '_tree_parents': {
                 "title": "Parents",

--- a/alignak_backend/models/servicegroup.py
+++ b/alignak_backend/models/servicegroup.py
@@ -131,6 +131,8 @@ def get_schema():
                     'resource': 'servicegroup',
                     'embeddable': True
                 },
+                'nullable': True,
+                'default': None
             },
             '_tree_parents': {
                 "title": "Parents",

--- a/alignak_backend/models/usergroup.py
+++ b/alignak_backend/models/usergroup.py
@@ -115,6 +115,8 @@ def get_schema():
                     'resource': 'usergroup',
                     'embeddable': True
                 },
+                'nullable': True,
+                'default': None
             },
             '_tree_parents': {
                 "title": "Parents",


### PR DESCRIPTION
Closes #401 : exception when getting groups without any _parent property