### PR TITLE
Update uwsgi startup script: environment variables

### DIFF
--- a/bin/alignak-backend-uwsgi
+++ b/bin/alignak-backend-uwsgi
@@ -1,1 +1,16 @@
-uwsgi --ini /usr/local/etc/alignak-backend/uwsgi.ini
+#!/bin/sh
+if [ ${ALIGNAK_BACKEND_UWSGI_FILE} ]; then
+    ALIGNAK_BACKEND_UWSGI_CFG="$ALIGNAK_BACKEND_UWSGI_FILE"
+else
+    ALIGNAK_BACKEND_UWSGI_CFG="/usr/local/etc/alignak-backend/uwsgi.ini"
+fi
+echo "Alignak backend uWSGI configuration file: ${ALIGNAK_BACKEND_UWSGI_CFG}"
+
+if [ ${ALIGNAK_BACKEND_CONFIGURATION_FILE} ]; then
+    ALIGNAK_BACKEND_CFG="$ALIGNAK_BACKEND_CONFIGURATION_FILE"
+else
+    ALIGNAK_BACKEND_CFG="/usr/local/etc/alignak-backend/settings.json"
+fi
+echo "Alignak backend configuration file: ${ALIGNAK_BACKEND_CFG}"
+
+uwsgi --ini "$ALIGNAK_BACKEND_UWSGI_CFG"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,11 +6,16 @@ Configuration
 Introduction
 ------------
 
-The backend uses a configuration file.
-It is located in one of these folders:
+The backend uses a configuration file that is located in one of these folders:
 
-* /usr/local/etc/alignak_backend/settings.json
-* /etc/alignak_backend/settings.json
+   * /usr/local/etc/alignak_backend/settings.json
+   * /etc/alignak_backend/settings.json
+   * etc/alignak_backend/settings.json
+   * ./etc/settings.json
+   * ../etc/settings.json
+   * ./settings.json
+
+If an environment variable `ALIGNAK_BACKEND_CONFIGURATION_FILE` exist, the file name defined in this variable takes precedence over the default files list.
 
 It's a JSON structured file.
 

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -23,7 +23,7 @@ The Alignak backend logs its activity in two files that are located in */usr/loc
 
 * *alignak-backend-error.log* contains the other messages: start, stop, activity log, ...
 
-.. warning:: If you do not have those files when the backend is started, make sure that the user account used to run the backend is allow to write in the */usr/local/var/log* directory ;)
+.. warning:: If you do not have those files when the backend is started, make sure that the user account used to run the backend is allowed to write in the */usr/local/var/log* directory ;)
 
 
 Developer mode
@@ -78,6 +78,14 @@ On start, some useful information are printed on the console::
 
 
 Alignak-backend runs on port 5000, so you should use ``http://ip:5000/`` as a base URL for the API.
+
+Environment variables
+---------------------
+
+If an environment variable `ALIGNAK_BACKEND_CONFIGURATION_FILE` exist, the file name defined in this variable takes precedence over the default files list.
+
+If an environment variable `ALIGNAK_BACKEND_UWSGI_FILE` exist, the `alignak-backend-uwsgi` script will use the file name defined in this variable as the uWSGI configuration file.
+
 
 Change default admin password
 -----------------------------


### PR DESCRIPTION
This to allow the `alignak-backend-uwsgi` to use environment variables for the uWSGI configuration file location