### PR TITLE
Closes #462 and #463 - log check results

### DIFF
--- a/alignak_backend/models/host.py
+++ b/alignak_backend/models/host.py
@@ -40,7 +40,7 @@ def get_schema():
         'schema': {
             'schema_version': {
                 'type': 'integer',
-                'default': 1,
+                'default': 2,
             },
             # Importation source
             'imported_from': {
@@ -803,13 +803,6 @@ def get_schema():
                 'type': 'boolean',
                 'default': False
             },
-            'ls_impact': {
-                'schema_version': 1,
-                'title': 'Impact',
-                'comment': 'Is an impact?',
-                'type': 'boolean',
-                'default': False
-            },
             'ls_last_check': {
                 'schema_version': 1,
                 'title': 'Check timestamp',
@@ -833,13 +826,8 @@ def get_schema():
                 'default': 'HARD',
                 'allowed': ['HARD', 'SOFT']
             },
-            'ls_last_state_changed': {
-                'schema_version': 1,
-                'title': 'Last state changed',
-                'comment': 'Last state changed timestamp',
-                'type': 'integer',
-                'default': 0
-            },
+
+            # Not in the host LCR
             'ls_next_check': {
                 'schema_version': 1,
                 'title': 'Next check',
@@ -907,16 +895,21 @@ def get_schema():
                 'default': False
             },
 
-            # todo - Attempt number - difference with ls_current_attemp?
-            'ls_attempt': {
-                'schema_version': 1,
-                'title': 'Current attempt number',
-                'comment': '',
+            # Last time state changed
+            'ls_state_changed': {
+                'schema_version': 2,
+                'title': 'State changed',
+                'comment': 'The state has changed with the last check?',
                 'type': 'integer',
                 'default': 0
             },
-
-            # Last time hard state changed
+            'ls_last_state_changed': {
+                'schema_version': 1,
+                'title': 'Last state changed',
+                'comment': 'Last state changed timestamp',
+                'type': 'integer',
+                'default': 0
+            },
             'ls_last_hard_state_changed': {
                 'schema_version': 1,
                 'title': 'Last time hard state changed',
@@ -926,6 +919,7 @@ def get_schema():
             },
 
             # Last time in the corresponding state
+            # Not in the host LCR
             'ls_last_time_up': {
                 'schema_version': 1,
                 'title': 'Last time up',
@@ -1083,5 +1077,20 @@ def get_schema():
                 'default': []
             },
         },
-        'schema_deleted': {}
+        'schema_deleted': {
+            'ls_impact': {
+                'schema_version': 1,
+                'title': 'Impact',
+                'comment': 'Is an impact?',
+                'type': 'boolean',
+                'default': False
+            },
+            'ls_attempt': {
+                'schema_version': 1,
+                'title': 'Current attempt number',
+                'comment': '',
+                'type': 'integer',
+                'default': 0
+            },
+        },
     }

--- a/alignak_backend/models/logcheckresult.py
+++ b/alignak_backend/models/logcheckresult.py
@@ -40,17 +40,18 @@ def get_schema():
         'schema': {
             'schema_version': {
                 'type': 'integer',
-                'default': 1,
+                'default': 2,
             },
             'host': {
-                'schema_version': 1,
-                'title': 'Concerned host',
+                'schema_version': 2,
+                'title': 'Concerned host identifier',
                 'type': 'objectid',
                 'data_relation': {
                     'resource': 'host',
                     'embeddable': True
                 },
-                'required': True,
+                # 'required': True,
+                'nullable': True
             },
             'host_name': {
                 'schema_version': 1,
@@ -62,15 +63,15 @@ def get_schema():
                 'regex': '^[^`~!$%^&*"|\'<>?,()=]+$'
             },
             'service': {
-                'schema_version': 1,
-                'title': 'Concerned service',
+                'schema_version': 2,
+                'title': 'Concerned service identifier',
                 'comment': 'If not set, this check result is an host check',
                 'type': 'objectid',
                 'data_relation': {
                     'resource': 'service',
                     'embeddable': True
                 },
-                'required': True,
+                # 'required': True,
                 'nullable': True
             },
             'service_name': {
@@ -152,18 +153,6 @@ def get_schema():
                 'type': 'integer',
                 'default': 0
             },
-            'last_state_changed': {
-                'schema_version': 1,
-                'title': 'Last state changed',
-                'type': 'integer',
-                'default': 0
-            },
-            'state_changed': {
-                'schema_version': 1,
-                'title': 'State changed',
-                'type': 'boolean',
-                'default': False
-            },
             'output': {
                 'schema_version': 1,
                 'title': 'Output',
@@ -193,6 +182,81 @@ def get_schema():
                 'title': 'Execution time',
                 'type': 'float',
                 'default': 0.0
+            },
+
+            'current_attempt': {
+                'schema_version': 2,
+                'title': 'Current attempt number',
+                'comment': '',
+                'type': 'integer',
+                'default': 0
+            },
+            'max_attempts': {
+                'schema_version': 2,
+                'title': 'Maximum attempts',
+                'comment': '',
+                'type': 'integer',
+                'default': 0
+            },
+
+            # Last time hard state changed
+            'state_changed': {
+                'schema_version': 1,
+                'title': 'State changed',
+                'comment': 'The state has changed with the last check?',
+                'type': 'boolean',
+                'default': False
+            },
+            'last_state_changed': {
+                'schema_version': 1,
+                'title': 'Last state changed',
+                'comment': 'Last time the state changed',
+                'type': 'integer',
+                'default': 0
+            },
+            'last_hard_state_changed': {
+                'schema_version': 2,
+                'title': 'Last time hard state changed',
+                'comment': 'Last time this element hard state has changed.',
+                'type': 'integer',
+                'default': 0
+            },
+
+            # Last time in the corresponding state_id
+            'last_time_0': {
+                'schema_version': 2,
+                'title': 'Last time up/ok',
+                'comment': 'Last time this element was Up/Ok.',
+                'type': 'integer',
+                'default': 0
+            },
+            'last_time_1': {
+                'schema_version': 2,
+                'title': 'Last time Down/Warning',
+                'comment': 'Last time this element was Down/Warning.',
+                'type': 'integer',
+                'default': 0
+            },
+            'last_time_2': {
+                'schema_version': 2,
+                'title': 'Last time critical',
+                'comment': 'Last time this element was Critical.',
+                'type': 'integer',
+                'default': 0
+            },
+            'last_time_3': {
+                'schema_version': 2,
+                'title': 'Last time unknown',
+                'comment': 'Last time this element was Unknown.',
+                'type': 'integer',
+                'default': 0
+            },
+            'last_time_4': {
+                'schema_version': 2,
+                'title': 'Last time unreachable',
+                'comment': 'Last time this element was Unreachable.',
+                'type': 'integer',
+                'default': 0
             },
 
             # Realm

--- a/alignak_backend/models/service.py
+++ b/alignak_backend/models/service.py
@@ -40,7 +40,7 @@ def get_schema():
         'schema': {
             'schema_version': {
                 'type': 'integer',
-                'default': 1,
+                'default': 2,
             },
             # Importation source
             'imported_from': {
@@ -818,13 +818,6 @@ def get_schema():
                 'type': 'boolean',
                 'default': False
             },
-            'ls_impact': {
-                'schema_version': 1,
-                'title': 'Impact',
-                'comment': 'Is an impact?',
-                'type': 'boolean',
-                'default': False
-            },
             'ls_last_check': {
                 'schema_version': 1,
                 'title': 'Last check time',
@@ -855,6 +848,8 @@ def get_schema():
                 'type': 'integer',
                 'default': 0
             },
+
+            # Not in the service LCR
             'ls_next_check': {
                 'schema_version': 1,
                 'title': 'Next check',
@@ -922,16 +917,14 @@ def get_schema():
                 'default': False
             },
 
-            # todo - Attempt number - difference with ls_current_attemp?
-            'ls_attempt': {
-                'schema_version': 1,
-                'title': 'Current attempt number',
-                'comment': '',
+            # Last time state changed
+            'ls_state_changed': {
+                'schema_version': 2,
+                'title': 'Last time state changed',
+                'comment': 'Last time this element state has changed.',
                 'type': 'integer',
                 'default': 0
             },
-
-            # Last time hard state changed
             'ls_last_hard_state_changed': {
                 'schema_version': 1,
                 'title': 'Last time hard state changed',
@@ -1103,5 +1096,20 @@ def get_schema():
                 'default': []
             }
         },
-        'schema_deleted': {}
+        'schema_deleted': {
+            'ls_impact': {
+                'schema_version': 1,
+                'title': 'Impact',
+                'comment': 'Is an impact?',
+                'type': 'boolean',
+                'default': False
+            },
+            'ls_attempt': {
+                'schema_version': 1,
+                'title': 'Current attempt number',
+                'comment': '',
+                'type': 'integer',
+                'default': 0
+            }
+        }
     }


### PR DESCRIPTION
Closes #462: posting a logcheckresult will update the host/service live state
Closes #463: allow to post a logcheckresult with host_name and service_name (no need for identifiers)