### PR TITLE
Host/service state sent with the metrics

### DIFF
--- a/alignak_backend/app.py
+++ b/alignak_backend/app.py
@@ -465,8 +465,7 @@ def pre_logcheckresult_post(items):
     hosts_drv = current_app.data.driver.db['host']
     services_drv = current_app.data.driver.db['service']
     for dummy, item in enumerate(items):
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LCR - got a check result: %s" % item)
+        current_app.logger.debug("LCR - got a check result: %s" % item)
 
         if not item.get('host') and not item.get('host_name'):
             abort(make_response("Posting LCR without host information is not accepted.", 412))
@@ -502,13 +501,12 @@ def pre_logcheckresult_post(items):
         g.updateLivestate = True
         # If the log check result is older than the item last check, do not update the livestate
         if item_last_check and item['last_check'] < item_last_check:
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("LCR - will not update the livestate: %s / %s" % (item['last_check'],
-                                                                        item_last_check))
+            current_app.logger.debug("LCR - will not update the livestate: %s / %s",
+                                     item['last_check'], item_last_check)
             g.updateLivestate = False
 
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LCR - inserting an LCR for %s/%s..." % (item['host_name'], item['service_name']))
+        current_app.logger.debug("LCR - inserting an LCR for %s/%s...",
+                                 item['host_name'], item['service_name'])
 
 
 def after_insert_logcheckresult(items):
@@ -520,9 +518,9 @@ def after_insert_logcheckresult(items):
     :return: None
     """
     for dummy, item in enumerate(items):
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LCR - inserted an LCR for %s/%s..." % (item['host_name'], item['service_name']))
-            print("    -> %s..." % item)
+        current_app.logger.debug("LCR - inserted an LCR for %s/%s...",
+                                 item['host_name'], item['service_name'])
+        current_app.logger.debug("    -> %s..." % item)
 
         if g.updateLivestate:
             # Update the livestate...
@@ -586,8 +584,8 @@ def after_insert_logcheckresult(items):
                 }
                 (pi_a, pi_b, pi_c, pi_d) = patch_internal('host', data, False, False, **lookup)
 
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("LCR - updated the livestate: %s, %s, %s, %s" % (pi_a, pi_b, pi_c, pi_d))
+            current_app.logger.debug("LCR - updated the livestate: %s, %s, %s, %s",
+                                     pi_a, pi_b, pi_c, pi_d)
 
         # Create an history event for the new logcheckresult
         message = "%s[%s] (%s/%s): %s" % (item['state'], item['state_type'],
@@ -1295,8 +1293,7 @@ def pre_delete_host(item):
     :type item: dict
     :return: None
     """
-    if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-        print("Deleting host: %s" % item['name'])
+    current_app.logger.debug("Deleting host: %s" % item['name'])
     services_drv = current_app.data.driver.db['service']
     services = services_drv.find({'host': item['_id']})
     for service in services:
@@ -1312,8 +1309,7 @@ def after_delete_host(item):
     :type item: dict
     :return: None
     """
-    if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-        print("Deleted host: %s" % item['name'])
+    current_app.logger.debug("Deleted host: %s", item['name'])
 
 
 # Alignak

--- a/alignak_backend/livesynthesis.py
+++ b/alignak_backend/livesynthesis.py
@@ -551,7 +551,7 @@ class Livesynthesis(object):
 
     @staticmethod
     def on_fetched_item_history(response):
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-nested-blocks
         """
         Add to response some more information.
         We manage the 2 special parameters:
@@ -581,6 +581,8 @@ class Livesynthesis(object):
                 for lives in livesynthesis:
                     livesynthesis_id.append(lives['_id'])
                     for prop in [x for x in lives if not x.startswith('_')]:
+                        if prop in ['hosts_business_impact', 'services_business_impact']:
+                            continue
                         response[prop] += lives[prop]
 
             else:
@@ -594,6 +596,8 @@ class Livesynthesis(object):
                     if lives['_id'] != response['_id']:
                         livesynthesis_id.append(lives['_id'])
                         for prop in [x for x in lives if not x.startswith('_')]:
+                            if prop in ['hosts_business_impact', 'services_business_impact']:
+                                continue
                             response[prop] += lives[prop]
 
         if history is not None:

--- a/alignak_backend/livesynthesis.py
+++ b/alignak_backend/livesynthesis.py
@@ -24,16 +24,14 @@ class Livesynthesis(object):
         """
             Recalculate all the live synthesis counters
         """
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - Recalculating...")
+        current_app.logger.debug("LS - Recalculating...")
         livesynthesis = current_app.data.driver.db['livesynthesis']
         realmsdrv = current_app.data.driver.db['realm']
         allrealms = realmsdrv.find()
         for _, realm in enumerate(allrealms):
             live_current = livesynthesis.find_one({'_realm': realm['_id']})
             if live_current is None:
-                if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                    print("     new LS for realm %s" % realm['name'])
+                current_app.logger.debug("     new LS for realm %s", realm['name'])
                 data = {
                     'hosts_total': 0,
                     'hosts_not_monitored': 0,
@@ -125,8 +123,7 @@ class Livesynthesis(object):
                 'ls_downtimed': True, '_realm': realm['_id']
             }).count()
 
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("     realm %s, hosts LS: %s" % (realm['name'], data))
+            current_app.logger.debug("     realm %s, hosts LS: %s", realm['name'], data)
 
             lookup = {"_id": live_current['_id']}
             patch_internal('livesynthesis', data, False, False, **lookup)
@@ -217,8 +214,7 @@ class Livesynthesis(object):
                 'ls_downtimed': True, '_realm': realm['_id']
             }).count()
 
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("     realm %s, services LS: %s" % (realm['name'], data))
+            current_app.logger.debug("     realm %s, services LS: %s", realm['name'], data)
 
             lookup = {"_id": live_current['_id']}
             patch_internal('livesynthesis', data, False, False, **lookup)
@@ -249,8 +245,7 @@ class Livesynthesis(object):
                     data = {"$inc": {"%s_%s_%s" % (typecheck, item['ls_state'].lower(),
                                                    item['ls_state_type'].lower()): 1,
                                      "%s_total" % typecheck: 1}}
-                if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                    print("LS - inserted host %s: %s..." % (item['name'], data))
+                current_app.logger.debug("LS - inserted host %s: %s...", item['name'], data)
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
                 # Send livesynthesis to TSDB
@@ -280,8 +275,7 @@ class Livesynthesis(object):
                     data = {"$inc": {"%s_%s_%s" % (typecheck, item['ls_state'].lower(),
                                                    item['ls_state_type'].lower()): 1,
                                      "%s_total" % typecheck: 1}}
-                if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                    print("LS - inserted service %s: %s..." % (item['name'], data))
+                current_app.logger.debug("LS - inserted service %s: %s...", item['name'], data)
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
                 # Send livesynthesis to TSDB
@@ -316,8 +310,7 @@ class Livesynthesis(object):
                 data = {"$inc": {minus: -1}}
                 if plus is not False:
                     data = {"$inc": {minus: -1, plus: 1}}
-                if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                    print("LS - updated host %s: %s..." % (original['name'], data))
+                current_app.logger.debug("LS - updated host %s: %s...", original['name'], data)
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
                 # Send livesynthesis to TSDB
@@ -354,8 +347,8 @@ class Livesynthesis(object):
                 data = {"$inc": {minus: -1}}
                 if plus is not False:
                     data = {"$inc": {minus: -1, plus: 1}}
-                if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                    print("LS - updated service %s: %s..." % (original['name'], data))
+                current_app.logger.debug("LS - updated service %s: %s...",
+                                         original['name'], data)
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
                 # Send livesynthesis to TSDB
@@ -381,8 +374,7 @@ class Livesynthesis(object):
         else:
             minus = Livesynthesis.livesynthesis_to_delete('hosts', item)
             data = {"$inc": {minus: -1, 'hosts_total': -1}}
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("LS - Deleted host %s: %s" % (item['name'], data))
+            current_app.logger.debug("LS - Deleted host %s: %s", item['name'], data)
             current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
             # Send livesynthesis to TSDB
@@ -395,8 +387,7 @@ class Livesynthesis(object):
 
         :return: None
         """
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - Deleted all hosts...")
+        current_app.logger.debug("LS - Deleted all hosts...")
         ls = Livesynthesis()
         ls.recalculate()
 
@@ -419,8 +410,7 @@ class Livesynthesis(object):
         else:
             minus = Livesynthesis.livesynthesis_to_delete('services', item)
             data = {"$inc": {minus: -1, 'services_total': -1}}
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("LS - Deleted service %s: %s" % (item['name'], data))
+            current_app.logger.debug("LS - Deleted service %s: %s", item['name'], data)
             current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
             # Send livesynthesis to TSDB
@@ -433,8 +423,7 @@ class Livesynthesis(object):
 
         :return: None
         """
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - Deleted all services...")
+        current_app.logger.debug("LS - Deleted all services...")
         # the most simple method is to recalculate the livesynthesis
         ls = Livesynthesis()
         ls.recalculate()
@@ -463,8 +452,7 @@ class Livesynthesis(object):
         # Downtime modification
         if item['ls_downtimed']:
             minus = "%s_in_downtime" % (type_check)
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - Deleting %s..." % minus)
+        current_app.logger.debug("LS - Deleting %s...", minus)
         return minus
 
     @staticmethod
@@ -486,8 +474,7 @@ class Livesynthesis(object):
                 and 'ls_acknowledged' not in updated and 'ls_downtimed' not in updated:
             return False, False
 
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - updating: %s" % updated)
+        current_app.logger.debug("LS - updating: %s", updated)
         plus = False
         minus = "%s_%s_%s" % (type_check, original['ls_state'].lower(),
                               original['ls_state_type'].lower())
@@ -542,8 +529,7 @@ class Livesynthesis(object):
         elif 'ls_downtimed' in original and original['ls_downtimed']:
             return False, False
 
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("     updating: -%s / +%s" % (minus, plus))
+        current_app.logger.debug("     updating: -%s / +%s", minus, plus)
         if minus == plus:
             return False, False
 
@@ -569,8 +555,7 @@ class Livesynthesis(object):
         history = request.args.get('history')
         concatenation = request.args.get('concatenation')
 
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("LS - History: %s / %s" % (history, concatenation))
+        current_app.logger.debug("LS - History: %s / %s", history, concatenation)
         if concatenation is not None:
             # get the realm the user have access
             realm = realm_drv.find_one({'_id': response['_realm']})
@@ -623,8 +608,7 @@ class Livesynthesis(object):
                             response['history'][num][prop] += lsretention[prop]
                     num += 1
 
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            if 'history' in response:
-                print("LS - History: %s" % response['history'])
-            else:
-                print("LS - History: no history!")
+        if 'history' in response:
+            current_app.logger.debug("LS - History: %s", response['history'])
+        else:
+            current_app.logger.debug("LS - History: no history!")

--- a/alignak_backend/livesynthesis.py
+++ b/alignak_backend/livesynthesis.py
@@ -46,7 +46,6 @@ class Livesynthesis(object):
                     'hosts_acknowledged': 0,
                     'hosts_in_downtime': 0,
                     'hosts_flapping': 0,
-                    'hosts_business_impact': 0,
                     'services_total': 0,
                     'services_not_monitored': 0,
                     'services_ok_hard': 0,
@@ -62,7 +61,6 @@ class Livesynthesis(object):
                     'services_acknowledged': 0,
                     'services_in_downtime': 0,
                     'services_flapping': 0,
-                    'services_business_impact': 0,
                     '_realm': realm['_id']
                 }
                 livesynthesis.insert(data)
@@ -133,7 +131,7 @@ class Livesynthesis(object):
             lookup = {"_id": live_current['_id']}
             patch_internal('livesynthesis', data, False, False, **lookup)
 
-            # Send livesynthesis to TSDB
+            # Send livesynthesis to TSDB
             Timeseries.send_livesynthesis_metrics(realm['_id'], data)
 
             # Update services live synthesis
@@ -225,7 +223,7 @@ class Livesynthesis(object):
             lookup = {"_id": live_current['_id']}
             patch_internal('livesynthesis', data, False, False, **lookup)
 
-            # Send livesynthesis to TSDB
+            # Send livesynthesis to TSDB
             Timeseries.send_livesynthesis_metrics(realm['_id'], data)
 
     @staticmethod
@@ -255,7 +253,7 @@ class Livesynthesis(object):
                     print("LS - inserted host %s: %s..." % (item['name'], data))
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-                # Send livesynthesis to TSDB
+                # Send livesynthesis to TSDB
                 live_current = livesynthesis_db.find_one({'_realm': item['_realm']})
                 Timeseries.send_livesynthesis_metrics(item['_realm'], live_current)
 
@@ -286,7 +284,7 @@ class Livesynthesis(object):
                     print("LS - inserted service %s: %s..." % (item['name'], data))
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-                # Send livesynthesis to TSDB
+                # Send livesynthesis to TSDB
                 live_current = livesynthesis_db.find_one({'_realm': item['_realm']})
                 Timeseries.send_livesynthesis_metrics(item['_realm'], live_current)
 
@@ -322,7 +320,7 @@ class Livesynthesis(object):
                     print("LS - updated host %s: %s..." % (original['name'], data))
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-                # Send livesynthesis to TSDB
+                # Send livesynthesis to TSDB
                 live_current = livesynthesis_db.find_one({'_realm': original['_realm']})
                 Timeseries.send_livesynthesis_metrics(original['_realm'], live_current)
 
@@ -360,7 +358,7 @@ class Livesynthesis(object):
                     print("LS - updated service %s: %s..." % (original['name'], data))
                 current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-                # Send livesynthesis to TSDB
+                # Send livesynthesis to TSDB
                 live_current = livesynthesis_db.find_one({'_realm': original['_realm']})
                 Timeseries.send_livesynthesis_metrics(original['_realm'], live_current)
 
@@ -387,7 +385,7 @@ class Livesynthesis(object):
                 print("LS - Deleted host %s: %s" % (item['name'], data))
             current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-            # Send livesynthesis to TSDB
+            # Send livesynthesis to TSDB
             live_current = livesynthesis_db.find_one({'_realm': item['_realm']})
             Timeseries.send_livesynthesis_metrics(item['_realm'], live_current)
 
@@ -425,7 +423,7 @@ class Livesynthesis(object):
                 print("LS - Deleted service %s: %s" % (item['name'], data))
             current_app.data.driver.db.livesynthesis.update({'_id': live_current['_id']}, data)
 
-            # Send livesynthesis to TSDB
+            # Send livesynthesis to TSDB
             live_current = livesynthesis_db.find_one({'_realm': item['_realm']})
             Timeseries.send_livesynthesis_metrics(item['_realm'], live_current)
 

--- a/alignak_backend/models/livesynthesis.py
+++ b/alignak_backend/models/livesynthesis.py
@@ -116,12 +116,6 @@ def get_schema():
                 'type': 'integer',
                 'default': 0
             },
-            'hosts_business_impact': {
-                'schema_version': 1,
-                'title': 'Hosts business impact',
-                'type': 'integer',
-                'default': 0
-            },
 
             'services_total': {
                 'schema_version': 1,
@@ -213,12 +207,6 @@ def get_schema():
                 'type': 'integer',
                 'default': 0
             },
-            'services_business_impact': {
-                'schema_version': 1,
-                'title': 'Services business impact',
-                'type': 'integer',
-                'default': 0
-            },
 
             # Realm
             '_realm': {
@@ -253,5 +241,18 @@ def get_schema():
                 },
             },
         },
-        'schema_deleted': {}
+        'schema_deleted': {
+            'hosts_business_impact': {
+                'schema_version': 2,
+                'title': 'Hosts business impact',
+                'type': 'integer',
+                'default': 0
+            },
+            'services_business_impact': {
+                'schema_version': 2,
+                'title': 'Services business impact',
+                'type': 'integer',
+                'default': 0
+            }
+        }
     }

--- a/alignak_backend/models/livesynthesisretention.py
+++ b/alignak_backend/models/livesynthesisretention.py
@@ -12,7 +12,7 @@ def get_name(friendly=False):
     :rtype: str
     """
     if friendly:  # pragma: no cover
-        return 'LS history'
+        return 'Alignak live state history'
     return 'livesynthesisretention'
 
 
@@ -33,14 +33,6 @@ def get_doc():  # pragma: no cover
 def get_schema():
     """Schema structure of this resource
 
-    For an element type and a state, store values computed from the hosts/services livestate:
-    - a counter containing the number of element_type in the state
-    - a percentage of element_type in the state
-    - a counter containing the number of element_type in the state and acknowledged
-    - a counter containing the number of element_type in the state and in downtime
-    - a counter containing the number of element_type in the state and flapping
-    - the maximum business impact of the element_type in the state
-
     :return: schema dictionary
     :rtype: dict
     """
@@ -49,135 +41,162 @@ def get_schema():
         'schema': {
             'schema_version': {
                 'type': 'integer',
-                'default': 1,
+                'default': 2,
             },
             'hosts_total': {
                 'schema_version': 1,
+                'title': 'Hosts count',
+                'type': 'integer',
+                'default': 0,
+            },
+            'hosts_not_monitored': {
+                'schema_version': 2,
+                'title': 'Hosts not monitored',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_up_hard': {
                 'schema_version': 1,
+                'title': 'Hosts Up hard',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_up_soft': {
                 'schema_version': 1,
+                'title': 'Hosts Up soft',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_down_hard': {
                 'schema_version': 1,
+                'title': 'Hosts Down hard',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_down_soft': {
                 'schema_version': 1,
+                'title': 'Hosts Down soft',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_unreachable_hard': {
                 'schema_version': 1,
+                'title': 'Hosts Unreachable hard',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_unreachable_soft': {
                 'schema_version': 1,
+                'title': 'Hosts Unreachable soft',
                 'type': 'integer',
                 'default': 0,
             },
             'hosts_acknowledged': {
                 'schema_version': 1,
+                'title': 'Hosts ackowledged',
                 'type': 'integer',
                 'default': 0
             },
             'hosts_in_downtime': {
                 'schema_version': 1,
+                'title': 'Hosts in downtime',
                 'type': 'integer',
                 'default': 0
             },
             'hosts_flapping': {
                 'schema_version': 1,
+                'title': 'Hosts flapping',
                 'type': 'integer',
                 'default': 0
             },
-            'hosts_business_impact': {
-                'schema_version': 1,
-                'type': 'integer',
-                'default': 0
-            },
+
             'services_total': {
                 'schema_version': 1,
+                'title': 'Services count',
+                'type': 'integer',
+                'default': 0,
+            },
+            'services_not_monitored': {
+                'schema_version': 2,
+                'title': 'Services not monitored',
                 'type': 'integer',
                 'default': 0,
             },
             'services_ok_hard': {
                 'schema_version': 1,
+                'title': 'Services Ok hard',
                 'type': 'integer',
                 'default': 0,
             },
             'services_ok_soft': {
                 'schema_version': 1,
+                'title': 'Services Ok soft',
                 'type': 'integer',
                 'default': 0,
             },
             'services_warning_hard': {
                 'schema_version': 1,
+                'title': 'Services Warning hard',
                 'type': 'integer',
                 'default': 0,
             },
             'services_warning_soft': {
                 'schema_version': 1,
+                'title': 'Services Warning soft',
                 'type': 'integer',
                 'default': 0,
             },
             'services_critical_hard': {
                 'schema_version': 1,
+                'title': 'Services Critical hard',
                 'type': 'integer',
                 'default': 0,
             },
             'services_critical_soft': {
                 'schema_version': 1,
+                'title': 'Services Criticl soft',
                 'type': 'integer',
                 'default': 0,
             },
             'services_unknown_hard': {
                 'schema_version': 1,
+                'title': 'Services Unknown hard',
                 'type': 'integer',
                 'default': 0,
             },
             'services_unknown_soft': {
                 'schema_version': 1,
+                'title': 'Services Unknown soft',
                 'type': 'integer',
                 'default': 0,
             },
             'services_unreachable_hard': {
                 'schema_version': 1,
+                'title': 'Services Unreachable hard',
                 'type': 'integer',
                 'default': 0,
             },
             'services_unreachable_soft': {
                 'schema_version': 1,
+                'title': 'Services Unreachable soft',
                 'type': 'integer',
                 'default': 0,
             },
             'services_acknowledged': {
                 'schema_version': 1,
+                'title': 'Services acknowledged',
                 'type': 'integer',
                 'default': 0
             },
             'services_in_downtime': {
                 'schema_version': 1,
+                'title': 'Services in downtime',
                 'type': 'integer',
                 'default': 0
             },
             'services_flapping': {
                 'schema_version': 1,
-                'type': 'integer',
-                'default': 0
-            },
-            'services_business_impact': {
-                'schema_version': 1,
+                'title': 'Services flapping',
                 'type': 'integer',
                 'default': 0
             },
@@ -190,5 +209,18 @@ def get_schema():
                 'required': True,
             }
         },
-        'schema_deleted': {}
+        'schema_deleted': {
+            'hosts_business_impact': {
+                'schema_version': 2,
+                'title': 'Hosts business impact',
+                'type': 'integer',
+                'default': 0
+            },
+            'services_business_impact': {
+                'schema_version': 2,
+                'title': 'Services business impact',
+                'type': 'integer',
+                'default': 0
+            }
+        }
     }

--- a/alignak_backend/timeseries.py
+++ b/alignak_backend/timeseries.py
@@ -63,13 +63,11 @@ class Timeseries(object):
         for counter in livesynthesis:
             if counter.startswith('_'):
                 continue
-            if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-                print("   - counter: %s" % (counter))
+            current_app.logger.debug("   - counter: %s", counter)
             ls['perf_data'].append("%s=%d" % (counter, livesynthesis[counter]))
 
         ls['perf_data'] = " ".join(ls['perf_data'])
-        if 'ALIGNAK_BACKEND_PRINT' in os.environ:
-            print("   - perf_data: %s" % (ls['perf_data']))
+        current_app.logger.debug("   - perf_data: %s", ls['perf_data'])
 
         now = int(time.time())
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -217,6 +217,49 @@ Curl example::
 	}
     ]' "http://192.168.0.10:5000/influxdb"
 
+Live synthesis
+~~~~~~~~~~~~~~
+
+As soon as an host or service check result is received by the backend (POST /logcheckresult), the backend `livesynthesis` collection is updated to reflect the global hosts and services state counters.
+
+ The live synthesis is kept up-to-date for each realm known in the backend. It contains the following counters:
+::
+
+    'hosts_total': 13,
+    'hosts_not_monitored': 0,
+    'hosts_business_impact': 0,
+    'hosts_up_hard': 3,
+    'hosts_up_soft': 0,
+    'hosts_down_hard': 14,
+    'hosts_down_soft': -4,
+    'hosts_unreachable_hard': 0,
+    'hosts_unreachable_soft': 0,
+    'hosts_acknowledged': 0,
+    'hosts_flapping': 0,
+    'hosts_in_downtime': 0,
+
+    'services_total': 89,
+    'services_not_monitored': 0,
+    'services_business_impact': 0,
+    'services_ok_hard': 8,
+    'services_ok_soft': 0,
+    'services_warning_hard': 0,
+    'services_warning_soft': 0,
+    'services_critical_hard': 83,
+    'services_critical_soft': 23,
+    'services_unknown_hard': 24,
+    'services_unknown_soft': 0,
+    'services_unreachable_hard': 4,
+    'services_unreachable_soft': 1,
+    'services_acknowledged': 0,
+    'services_flapping': 0,
+    'services_in_downtime': 0,
+
+
+As soon as the livesynthesis is changing for a realm, the Alignak backend will push the livesynthesis counters to the configured timeseries databases. As such, it will exist a fake host `alignak_livesynthesis` in the metrics and this host will have all the livesynthesis counters attached to.
+
+This feature may be disabled thanks to an environment variable. Define an environment variable named `ALIGNAK_BACKEND_LIVESYNTHESIS_TSDB` and valued with '0' to disable the livesynthesis counters sending to the TSDB.
+
 Manage retention
 ~~~~~~~~~~~~~~~~
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,10 +13,10 @@ To use this Alignak backend, you first need to install and run MongoDB_
 
 .. _MongoDB: http://docs.mongodb.org/manual/
 
-As an excerpt of the MongoDB installation documentation, this script will install the Mongo DB community edition on a Linux Ubuntu 16::
+As an excerpt of the MongoDB installation documentation, this script will install the Mongo DB community edition on a Linux Ubuntu 16 (https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)::
 
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/testing multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
     sudo apt-get update
     sudo apt-get install -y mongodb-org
     sudo service mongod start

--- a/docs/resources/userrestrictrole.rst
+++ b/docs/resources/userrestrictrole.rst
@@ -7,7 +7,7 @@ User role restriction (userrestrictrole)
     The ``userrestrictrole`` model is an internal data model used to define the CRUD
     rights for an Alignak backend user.
 
-    This allows to defined, for a user and a given realm, the create, read, update, and
+    This allows to define, for a user and a given realm, the create, read, update, and
     delete rights on each backend endpoint.
     
 

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -47,6 +47,8 @@ If an environment variable `ALIGNAK_BACKEND_CONFIGURATION_FILE` exist, the file
 
 If an environment variable `ALIGNAK_BACKEND_UWSGI_FILE` exist, the `alignak-backend-uwsgi` script will use the file name defined in this variable as the uWSGI configuration file.
 
+If an environment variable `ALIGNAK_BACKEND_LIVESYNTHESIS_TSDB` exist, and its value equals '0' then the counters of the livesynthesis will not be set to the timeseries databases.
+
 
 system.d service mode
 ---------------------

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -17,13 +17,12 @@ Thanks to this, you can simply run:
 
     alignak-backend-uwsgi
 
-The Alignak backend logs its activity in two files that are located in */usr/local/var/log*:
+ When started with uWSGI the Alignak backend logs its activity in a file */usr/local/var/log/alignak-backend/backend-error.log*. This file is the log file built by the uWSGI server.
 
-* *alignak-backend-access.log* contains all the API HTTP requests
+.. warning:: If you do not have this file when the backend is started, make sure that the user account used to run the backend is allowed to write in the */usr/local/var/log* directory ;)
 
-* *alignak-backend-error.log* contains the other messages: start, stop, activity log, ...
+ The Alignak backend configuration allows to define and configure a logger that will log the backend API endpoints to file located in the same directory. see the configuration page for more information on how to configure this logger.
 
-.. warning:: If you do not have those files when the backend is started, make sure that the user account used to run the backend is allowed to write in the */usr/local/var/log* directory ;)
 
 To stop / reload the Alignak backend application:
 ::

--- a/test/test_grafana.py
+++ b/test/test_grafana.py
@@ -411,7 +411,7 @@ class TestGrafana(unittest2.TestCase):
 
         # test grafana class and code to create dashboard in grafana
         from alignak_backend.app import app, current_app
-        with app.app_context():
+        with app.test_request_context():
             grafana_db = current_app.data.driver.db['grafana']
             grafanas = grafana_db.find()
             for grafana in grafanas:
@@ -606,7 +606,7 @@ class TestGrafana(unittest2.TestCase):
 
         # test grafana class and code to create dashboard in grafana
         from alignak_backend.app import app, current_app
-        with app.app_context():
+        with app.test_request_context():
             grafana_db = current_app.data.driver.db['grafana']
             grafanas = grafana_db.find()
             for grafana in grafanas:

--- a/test/test_hook_livesynthesis.py
+++ b/test/test_hook_livesynthesis.py
@@ -14,9 +14,6 @@ import requests
 import unittest2
 from alignak_backend.livesynthesis import Livesynthesis
 
-# Set an environment variable to print debug information for the backend
-os.environ['ALIGNAK_BACKEND_PRINT'] = '1'
-
 
 class TestHookLivesynthesis(unittest2.TestCase):
     """
@@ -1982,53 +1979,55 @@ class TestHookLivesynthesis(unittest2.TestCase):
 
         :return: None
         """
-        # scenario 1
-        original = {
-            'ls_state': 'UP',
-            'ls_state_type': 'HARD',
-        }
-        updated = {
-            'ls_state': 'DOWN',
-            'ls_state_type': 'SOFT'
-        }
-        minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
-        self.assertEqual(minus, 'hosts_up_hard')
-        self.assertEqual(plus, 'hosts_down_soft')
+        from alignak_backend.app import app
+        with app.app_context():
+            # scenario 1
+            original = {
+                'ls_state': 'UP',
+                'ls_state_type': 'HARD',
+            }
+            updated = {
+                'ls_state': 'DOWN',
+                'ls_state_type': 'SOFT'
+            }
+            minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
+            self.assertEqual(minus, 'hosts_up_hard')
+            self.assertEqual(plus, 'hosts_down_soft')
 
-        # scenario 2
-        original = {
-            'ls_state': 'UP',
-            'ls_state_type': 'SOFT',
-        }
-        updated = {
-            'ls_state': 'DOWN',
-        }
-        minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
-        self.assertEqual(minus, 'hosts_up_soft')
-        self.assertEqual(plus, 'hosts_down_soft')
+            # scenario 2
+            original = {
+                'ls_state': 'UP',
+                'ls_state_type': 'SOFT',
+            }
+            updated = {
+                'ls_state': 'DOWN',
+            }
+            minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
+            self.assertEqual(minus, 'hosts_up_soft')
+            self.assertEqual(plus, 'hosts_down_soft')
 
-        # scenario 3
-        original = {
-            'ls_state': 'UP',
-            'ls_state_type': 'SOFT',
-        }
-        updated = {
-            'ls_state_type': 'HARD',
-        }
-        minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
-        self.assertEqual(minus, 'hosts_up_soft')
-        self.assertEqual(plus, 'hosts_up_hard')
+            # scenario 3
+            original = {
+                'ls_state': 'UP',
+                'ls_state_type': 'SOFT',
+            }
+            updated = {
+                'ls_state_type': 'HARD',
+            }
+            minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
+            self.assertEqual(minus, 'hosts_up_soft')
+            self.assertEqual(plus, 'hosts_up_hard')
 
-        # scenario 4
-        original = {
-            'ls_state': 'UP',
-            'ls_state_type': 'SOFT',
-        }
-        updated = {
-        }
-        minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
-        self.assertFalse(minus)
-        self.assertFalse(plus)
+            # scenario 4
+            original = {
+                'ls_state': 'UP',
+                'ls_state_type': 'SOFT',
+            }
+            updated = {
+            }
+            minus, plus = Livesynthesis.livesynthesis_to_update('hosts', updated, original)
+            self.assertFalse(minus)
+            self.assertFalse(plus)
 
     def test_realms(self):  # pylint: disable=too-many-locals
         """

--- a/test/test_livesynthesis_history.py
+++ b/test/test_livesynthesis_history.py
@@ -353,7 +353,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -369,7 +368,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):
@@ -394,7 +392,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -410,7 +407,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         ref_old = {
             u'hosts_total': 3,
@@ -424,7 +420,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -440,7 +435,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 0,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         del resp['history'][0]['_created']
         self.assertEqual(resp['history'][0], ref)
@@ -471,7 +465,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -487,7 +480,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 0,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):
@@ -512,7 +504,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -528,7 +519,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 0,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         ref_old = {
             u'hosts_total': 3,
@@ -542,7 +532,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -558,7 +547,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 0,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         del resp['history'][0]['_created']
         self.assertEqual(resp['history'][0], ref)
@@ -590,7 +578,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -606,7 +593,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):
@@ -636,7 +622,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -652,7 +637,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         ref_middle = {
             u'hosts_total': 6,
@@ -666,7 +650,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -682,7 +665,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         ref_old = {
             u'hosts_total': 6,
@@ -696,7 +678,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -712,7 +693,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 0,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         del resp['history'][0]['_created']
         self.assertEqual(resp['history'][0], ref)
@@ -774,7 +754,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -790,7 +769,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):
@@ -814,7 +792,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 6,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -830,7 +807,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):
@@ -887,7 +863,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'hosts_acknowledged': 0,
             u'hosts_in_downtime': 0,
             u'hosts_flapping': 0,
-            u'hosts_business_impact': 0,
             u'services_total': 12,
             u'services_not_monitored': 0,
             u'services_ok_hard': 0,
@@ -903,7 +878,6 @@ class TestHookLivesynthesis(unittest2.TestCase):
             u'services_acknowledged': 1,
             u'services_in_downtime': 0,
             u'services_flapping': 0,
-            u'services_business_impact': 0
         }
         for prop in copy.copy(resp):
             if prop.startswith('_'):

--- a/test/test_logcheckresult.py
+++ b/test/test_logcheckresult.py
@@ -17,9 +17,6 @@ from datetime import datetime
 import requests
 import unittest2
 
-# Set an environment variable to print debug information for the backend
-os.environ['ALIGNAK_BACKEND_PRINT'] = '1'
-
 
 class TestLogcheckresult(unittest2.TestCase):
     """This class tests the logchekresult features"""

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -716,6 +716,10 @@ class TestTimeseries(unittest2.TestCase):
         }
         from alignak_backend.app import app, current_app
         with app.test_request_context():
+            # Drop the collection before posting the log check result
+            timeseriesretention_db = current_app.data.driver.db['timeseriesretention']
+            timeseriesretention_db.drop()
+
             # test with timeseries not available, it must be quick (< 3 seconds), because have
             # 2 graphites and 1 influx, so (2 + 1) * 1 second timeout * 2 (code execution between
             # each tries send to timeseries)
@@ -1114,6 +1118,10 @@ class TestTimeseries(unittest2.TestCase):
             '_sub_realm': True
         }
         with app.test_request_context():
+            # Drop the collection before posting the log check result
+            timeseriesretention_db = current_app.data.driver.db['timeseriesretention']
+            timeseriesretention_db.drop()
+
             # test with timeseries not available, it must be quick (< 3 seconds), because have
             # 3 graphites and 1 influx, so (3 + 1) * 1 second timeout * 2 (code execution
             # between each tries send to timeseries)
@@ -1123,7 +1131,6 @@ class TestTimeseries(unittest2.TestCase):
             assert execution_time < 8
 
             # check data in timeseriesretention
-            timeseriesretention_db = current_app.data.driver.db['timeseriesretention']
             retentions = timeseriesretention_db.find()
             retention_data = []
             for retention in retentions:
@@ -1193,7 +1200,7 @@ class TestTimeseries(unittest2.TestCase):
 
     def test_sanitized_host_service_names(self):
         # pylint: disable=too-many-locals
-        """Test that host and service names are sanitize before sending date
+        """Test that host and service names are sanitized before sending date
 
         :return: None
         """
@@ -1270,43 +1277,48 @@ class TestTimeseries(unittest2.TestCase):
         self.assertEqual('OK', resp['_status'], resp)
         host_id = resp['_id']
 
-        # add a service for this host
-        data = {
-            'name': 'My service',
-            'host': host_id,
-            'check_command': command_ping,
-            '_realm': self.realm_all,
-            '_sub_realm': False
-        }
-        response = requests.post(self.endpoint + '/service', json=data, headers=headers,
-                                 auth=self.auth)
-        resp = response.json()
-        self.assertEqual('OK', resp['_status'], resp)
-        service_id = resp['_id']
-
-        # === Test now with an host in realm All ===
-        # add logcheckresult for host001
-        # Metrics sent to Graphite 1, Graphite 2 and InfluxDB
-        item = {
-            'host': ObjectId(host_id),
-            'host_name': 'My host',
-            'service': ObjectId(service_id),
-            'service_name': 'My service',
-            'state': 'OK',
-            'state_type': 'HARD',
-            'state_id': 0,
-            # '_overall_state_id': 0,
-            'acknowledged': False,
-            'last_check': int(time.time()),
-            'last_state': 'OK',
-            'output': 'PING OK - Packet loss = 0%, RTA = 0.08 ms',
-            'long_output': '',
-            'perf_data': "rta=74.827003ms;100.000000;110.000000;0.000000 pl=0%;10;;0",
-            '_realm': ObjectId(self.realm_all),
-            '_sub_realm': False
-        }
         from alignak_backend.app import app, current_app
         with app.test_request_context():
+            # Drop the collection before posting the log check result
+            timeseriesretention_db = current_app.data.driver.db['timeseriesretention']
+            timeseriesretention_db.drop()
+
+            # add a service for this host
+            data = {
+                'name': 'My service',
+                'host': host_id,
+                'check_command': command_ping,
+                '_realm': self.realm_all,
+                '_sub_realm': False
+            }
+            response = requests.post(self.endpoint + '/service', json=data, headers=headers,
+                                     auth=self.auth)
+            resp = response.json()
+            self.assertEqual('OK', resp['_status'], resp)
+            service_id = resp['_id']
+
+            # === Test now with an host in realm All ===
+            # add logcheckresult for host001
+            # Metrics sent to Graphite 1, Graphite 2 and InfluxDB
+            item = {
+                'host': ObjectId(host_id),
+                'host_name': 'My host',
+                'service': ObjectId(service_id),
+                'service_name': 'My service',
+                'state': 'WARNING',
+                'state_type': 'HARD',
+                'state_id': 0,
+                # '_overall_state_id': 0,
+                'acknowledged': False,
+                'last_check': int(time.time()),
+                'last_state': 'OK',
+                'output': 'PING OK - Packet loss = 0%, RTA = 0.08 ms',
+                'long_output': '',
+                'perf_data': "rta=74.827003ms;100.000000;110.000000;0.000000 pl=0%;10;;0",
+                '_realm': ObjectId(self.realm_all),
+                '_sub_realm': False
+            }
+
             # test with timeseries not available, it must be quick (< 3 seconds), because have
             # 2 graphites and 1 influx, so (2 + 1) * 1 second timeout * 2 (code execution between
             # each tries send to timeseries)
@@ -1316,7 +1328,6 @@ class TestTimeseries(unittest2.TestCase):
             assert execution_time < 6
 
             # check data in timeseriesretention
-            timeseriesretention_db = current_app.data.driver.db['timeseriesretention']
             retentions = timeseriesretention_db.find()
             retention_data = []
             for retention in retentions:
@@ -1332,6 +1343,112 @@ class TestTimeseries(unittest2.TestCase):
                 })
             ref = [
                 # InfluxDB
+                {'influxdb': ObjectId(influxdb_001), 'value': u'1',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_total',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_not_monitored',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_flapping',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_acknowledged',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_in_downtime',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'1',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+
+                {'influxdb': ObjectId(influxdb_001), 'value': u'1',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_total',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_flapping',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_not_monitored',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_acknowledged',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_in_downtime',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'1',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_hard',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_soft',
+                 'service': u'', 'graphite': None, 'uom': u''},
+
                 {'influxdb': ObjectId(influxdb_001), 'value': u'3', 'host': u'My_host',
                  'realm': u'All', 'name': u'alignak_overall_state_id',
                  'service': u'My_service', 'graphite': None, 'uom': u''},
@@ -1364,6 +1481,86 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': None, 'uom': u'%'},
 
                 # Graphite 001
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_total',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_flapping',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_not_monitored',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_acknowledged',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_in_downtime',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_total',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_flapping',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_not_monitored',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_acknowledged',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_in_downtime',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+
                 {'influxdb': None, 'value': u'3', 'host': u'My_host',
                  'realm': u'All', 'name': u'alignak_overall_state_id',
                  'service': u'My_service', 'graphite': ObjectId(graphite_001), 'uom': u''},
@@ -1396,6 +1593,86 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': ObjectId(graphite_001), 'uom': u'%'},
 
                 # Graphite 002
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_total',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_flapping',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_not_monitored',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_acknowledged',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_in_downtime',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_down_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_up_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'hosts_unreachable_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_total',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_flapping',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_not_monitored',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_acknowledged',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_in_downtime',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_ok_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_warning_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_critical_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unreachable_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'1', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_hard',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'alignak_livesynthesis',
+                 'realm': u'All', 'name': u'services_unknown_soft',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+
                 {'influxdb': None, 'value': u'3', 'host': u'My_host',
                  'realm': u'All', 'name': u'alignak_overall_state_id',
                  'service': u'My_service', 'graphite': ObjectId(graphite_002), 'uom': u''},

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -125,6 +125,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -205,6 +206,8 @@ class TestTimeseries(unittest2.TestCase):
                     'value': 0,
                     'uom': ''
                 },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
                 {
                     'name': 'rta',
                     'value': 0.083,
@@ -242,6 +245,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -264,7 +268,9 @@ class TestTimeseries(unittest2.TestCase):
                     'name': 'em0_out_octet',
                     'value': 86608341539,
                     'uom': ''
-                }
+                },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
             ]
         }
         self.assertItemsEqual(reference['data'], ret['data'])
@@ -281,6 +287,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -319,6 +326,8 @@ class TestTimeseries(unittest2.TestCase):
                     'value': 7381,
                     'uom': 'MB'
                 },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
             ]
         }
         self.assertItemsEqual(reference['data'], ret['data'])
@@ -330,6 +339,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -368,6 +378,8 @@ class TestTimeseries(unittest2.TestCase):
                     'value': 8317,
                     'uom': 'MB'
                 },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
             ]
         }
         self.assertItemsEqual(reference['data'], ret['data'])
@@ -386,6 +398,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -409,6 +422,8 @@ class TestTimeseries(unittest2.TestCase):
                     'value': 1083,
                     'uom': 'c'
                 },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
             ]
         }
         self.assertItemsEqual(reference['data'], ret['data'])
@@ -426,6 +441,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -515,6 +531,8 @@ class TestTimeseries(unittest2.TestCase):
                     'value': 100,
                     'uom': '%'
                 },
+                {'name': 'alignak_state_id', 'uom': '', 'value': 0},
+                {'name': 'alignak_overall_state_id', 'uom': '', 'value': 0},
             ]
         }
         self.assertItemsEqual(reference['data'], ret['data'])
@@ -725,6 +743,12 @@ class TestTimeseries(unittest2.TestCase):
                 })
             ref = [
                 # InfluxDB
+                {'influxdb': ObjectId(influxdb_001), 'value': u'3', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'', 'graphite': None, 'uom': u''},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'74.827003', 'host': u'srv001',
                  'realm': u'All', 'name': u'rta', 'service': u'', 'graphite': None, 'uom': u'ms'},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'100', 'host': u'srv001',
@@ -747,6 +771,12 @@ class TestTimeseries(unittest2.TestCase):
                  'realm': u'All', 'name': u'pl_max', 'service': u'', 'graphite': None, 'uom': u'%'},
 
                 # Graphite 001
+                {'influxdb': None, 'value': u'3', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u''},
                 {'influxdb': None, 'value': u'74.827003', 'host': u'srv001', 'realm': u'All',
                  'name': u'rta', 'service': u'', 'graphite': ObjectId(graphite_001), 'uom': u'ms'},
                 {'influxdb': None, 'value': u'100', 'host': u'srv001', 'realm': u'All',
@@ -771,6 +801,12 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': ObjectId(graphite_001), 'uom': u'%'},
 
                 # Graphite 002
+                {'influxdb': None, 'value': u'3', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'srv001',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u''},
                 {'influxdb': None, 'value': u'74.827003', 'host': u'srv001', 'realm': u'All',
                  'name': u'rta', 'service': u'', 'graphite': ObjectId(graphite_002), 'uom': u'ms'},
                 {'influxdb': None, 'value': u'100', 'host': u'srv001', 'realm': u'All',
@@ -809,6 +845,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            # '_overall_state_id': 0, not existing for test purpose
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -846,6 +883,12 @@ class TestTimeseries(unittest2.TestCase):
 
             ref = [
                 # Graphite 001
+                {'influxdb': None, 'value': u'3', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_overall_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
                 {'influxdb': None, 'value': u'32.02453', 'host': u'srv003',
                  'realm': u'All.All A.All A1', 'name': u'rta', 'service': u'',
                  'graphite': ObjectId(graphite_001), 'uom': u'ms'},
@@ -873,6 +916,12 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': ObjectId(graphite_001), 'uom': u'%'},
 
                 # Influx 001
+                {'influxdb': ObjectId(influxdb_001), 'value': u'3', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_overall_state_id',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'srv003', 'realm': u'All.All A.All A1',
+                 'name': u'alignak_state_id', 'service': u'', 'graphite': None, 'uom': u''},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'32.02453',
                  'host': u'srv003', 'realm': u'All.All A.All A1', 'name': u'rta', 'service': u'',
                  'graphite': None, 'uom': u'ms'},
@@ -981,6 +1030,12 @@ class TestTimeseries(unittest2.TestCase):
 
             ref = [
                 # Graphite 001
+                {'influxdb': None, 'value': u'3', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_overall_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
                 {'influxdb': None, 'value': u'32.02453', 'host': u'srv003',
                  'realm': u'All.All A.All A1', 'name': u'rta', 'service': u'',
                  'graphite': ObjectId(graphite_001), 'uom': u'ms'},
@@ -1008,6 +1063,12 @@ class TestTimeseries(unittest2.TestCase):
                 # that is not able to detect if connection is available (UDP)!
 
                 # Influx 001
+                {'influxdb': ObjectId(influxdb_001), 'value': u'3', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_overall_state_id', 'service': u'',
+                 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0', 'host': u'srv003',
+                 'realm': u'All.All A.All A1', 'name': u'alignak_state_id', 'service': u'',
+                 'graphite': None, 'uom': u''},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'32.02453',
                  'host': u'srv003', 'realm': u'All.All A.All A1', 'name': u'rta', 'service': u'',
                  'graphite': None, 'uom': u'ms'},
@@ -1079,6 +1140,12 @@ class TestTimeseries(unittest2.TestCase):
 
             ref = [
                 # Graphite 001
+                {'influxdb': None, 'value': u'3', 'host': u'srv002',
+                 'realm': u'All.All A', 'name': u'alignak_overall_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'srv002',
+                 'realm': u'All.All A', 'name': u'alignak_state_id', 'service': u'',
+                 'graphite': ObjectId(graphite_001), 'uom': u''},
                 {'influxdb': None, 'value': u'32.02453', 'host': u'srv002',
                  'realm': u'All.All A', 'name': u'rta', 'service': u'',
                  'graphite': ObjectId(graphite_001), 'uom': u'ms'},
@@ -1099,6 +1166,12 @@ class TestTimeseries(unittest2.TestCase):
                 # Nothing for Graphite 2 because it is not sub-realm!
 
                 # Influx 001
+                {'influxdb': ObjectId(influxdb_001), 'value': u'3',
+                 'host': u'srv002', 'realm': u'All.All A', 'name': u'alignak_overall_state_id',
+                 'service': u'', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0',
+                 'host': u'srv002', 'realm': u'All.All A', 'name': u'alignak_state_id',
+                 'service': u'', 'graphite': None, 'uom': u''},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'32.02453',
                  'host': u'srv002', 'realm': u'All.All A', 'name': u'rta', 'service': u'',
                  'graphite': None, 'uom': u'ms'},
@@ -1222,6 +1295,7 @@ class TestTimeseries(unittest2.TestCase):
             'state': 'OK',
             'state_type': 'HARD',
             'state_id': 0,
+            # '_overall_state_id': 0,
             'acknowledged': False,
             'last_check': int(time.time()),
             'last_state': 'OK',
@@ -1258,6 +1332,12 @@ class TestTimeseries(unittest2.TestCase):
                 })
             ref = [
                 # InfluxDB
+                {'influxdb': ObjectId(influxdb_001), 'value': u'3', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'My_service', 'graphite': None, 'uom': u''},
+                {'influxdb': ObjectId(influxdb_001), 'value': u'0', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'My_service', 'graphite': None, 'uom': u''},
                 {'influxdb': ObjectId(influxdb_001), 'value': u'74.827003', 'host': u'My_host',
                  'realm': u'All', 'name': u'rta', 'service': u'My_service',
                  'graphite': None, 'uom': u'ms'},
@@ -1284,6 +1364,12 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': None, 'uom': u'%'},
 
                 # Graphite 001
+                {'influxdb': None, 'value': u'3', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'My_service', 'graphite': ObjectId(graphite_001), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'My_service', 'graphite': ObjectId(graphite_001), 'uom': u''},
                 {'influxdb': None, 'value': u'74.827003', 'host': u'My_host', 'realm': u'All',
                  'name': u'rta', 'service': u'My_service',
                  'graphite': ObjectId(graphite_001), 'uom': u'ms'},
@@ -1310,6 +1396,12 @@ class TestTimeseries(unittest2.TestCase):
                  'graphite': ObjectId(graphite_001), 'uom': u'%'},
 
                 # Graphite 002
+                {'influxdb': None, 'value': u'3', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_overall_state_id',
+                 'service': u'My_service', 'graphite': ObjectId(graphite_002), 'uom': u''},
+                {'influxdb': None, 'value': u'0', 'host': u'My_host',
+                 'realm': u'All', 'name': u'alignak_state_id',
+                 'service': u'My_service', 'graphite': ObjectId(graphite_002), 'uom': u''},
                 {'influxdb': None, 'value': u'74.827003', 'host': u'My_host', 'realm': u'All',
                  'name': u'rta', 'service': u'My_service',
                  'graphite': ObjectId(graphite_002), 'uom': u'ms'},


### PR DESCRIPTION
Add a metric `alignak_overall_state_id` in the host/service performance data sent to the TSDB.

This metric will allow to have some statistics in the TSDB for the host/service state. The idea is to be able to get some host/service availability reporting.

As of now, all host/services have this information but it would be interesting to have a configuration parameter for this feature.