### PR TITLE
Fix #511: allow correct parsing of JSON files with comments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 python-dateutil>=2.4.2
 docopt
 jsonschema
+jsmin==2.2.2
 eve-swagger
 configparser
 flask-bootstrap
@@ -20,4 +21,4 @@ Eve==0.7.9
 
 # uWSGI server - a recommended Web server to run the application in a production environment
 # uncomment this to install from the Python repository if not installed by the server packaging
-# uwsgi
+# uwsgi==0.2.16

--- a/test/cfg/settings/settings_escaped_slashes.json
+++ b/test/cfg/settings/settings_escaped_slashes.json
@@ -16,7 +16,7 @@
   "RATE_LIMIT_PATCH": null,   /* Limit number of PATCH requests */
   "RATE_LIMIT_DELETE": null,  /* Limit number of DELETE requests */
 
-  "MONGO_URI": "mongodb://localhost:27017/alignak-backend",
+  "MONGO_URI": "mongodb:\/\/localhost:27017\/alignak-backend",
   "MONGO_HOST": "localhost",          /* Address of MongoDB */
   "MONGO_PORT": 27017,                /* port of MongoDB */
   "MONGO_DBNAME": "alignak-backend",  /* Name of database in MongoDB */
@@ -32,17 +32,19 @@
   The Alignak backend will use this adress to notify Alignak about backend newly created
   or deleted items
   Set to an empty value to disable this feature
+  Notes:
+  - / characters must be \ escaped!
   */
-  "ALIGNAK_URL": "http://127.0.0.1:7770",
+  "ALIGNAK_URL": "http:\/\/127.0.0.1:7770",
 
   /* Alignak event reporting scheduler
   Every SCHEDULER_ALIGNAK_PERIOD, an event is raised to the ALIGNAK_URL if an host/realm/user
   was created or deleted
 
-  Only raise notifications every 10 minutes
+  Short period for tests
   */
-  "SCHEDULER_ALIGNAK_ACTIVE": true,
-  "SCHEDULER_ALIGNAK_PERIOD": 600,
+  "SCHEDULER_ALIGNAK_ACTIVE": false,
+  "SCHEDULER_ALIGNAK_PERIOD": 10,
 
   /* As soon as a Graphite or Influx is existing in the backend, the received metrics are sent
   to the corresponding TSDB. If the TSDB is not available, metrics are stored internally

--- a/test/cfg/settings/settings_uncommented.json
+++ b/test/cfg/settings/settings_uncommented.json
@@ -1,0 +1,44 @@
+{
+  "DEBUG": false,
+
+  "HOST": "",
+  "PORT": 5000,
+  "SERVER_NAME": null,
+
+  "X_DOMAINS": "*",
+
+  "PAGINATION_LIMIT": 5000,
+  "PAGINATION_DEFAULT": 50,
+
+  "RATE_LIMIT_GET": null,
+  "RATE_LIMIT_POST": null,
+  "RATE_LIMIT_PATCH": null,
+  "RATE_LIMIT_DELETE": null,
+
+  "MONGO_URI": "mongodb:\/\/localhost:27017\/alignak-backend",
+  "MONGO_HOST": "localhost",
+  "MONGO_PORT": 27017,
+  "MONGO_DBNAME": "alignak-backend",
+  "MONGO_USERNAME": null,
+  "MONGO_PASSWORD": null,
+
+  "IP_CRON": ["127.0.0.1"],
+
+
+  "LOGGER": "alignak-backend-logger.json",
+
+  "ALIGNAK_URL": "http:\/\/127.0.0.1:7770",
+
+  "SCHEDULER_ALIGNAK_ACTIVE": false,
+  "SCHEDULER_ALIGNAK_PERIOD": 10,
+
+  "SCHEDULER_TIMESERIES_ACTIVE": false,
+  "SCHEDULER_TIMESERIES_PERIOD": 10,
+  "SCHEDULER_GRAFANA_ACTIVE": false,
+  "SCHEDULER_GRAFANA_PERIOD": 120,
+
+  "GRAFANA_DATASOURCE": true,
+  "GRAFANA_DATASOURCE_QUERIES": "grafana_queries.json",
+  "GRAFANA_DATASOURCE_TABLES": "grafana_tables.json",
+  "SCHEDULER_LIVESYNTHESIS_HISTORY": 60
+}

--- a/test/cfg/settings/settings_unescaped.json
+++ b/test/cfg/settings/settings_unescaped.json
@@ -32,6 +32,8 @@
   The Alignak backend will use this adress to notify Alignak about backend newly created
   or deleted items
   Set to an empty value to disable this feature
+  Notes:
+  - / characters must be \ escaped!
   */
   "ALIGNAK_URL": "http://127.0.0.1:7770",
 
@@ -39,10 +41,10 @@
   Every SCHEDULER_ALIGNAK_PERIOD, an event is raised to the ALIGNAK_URL if an host/realm/user
   was created or deleted
 
-  Only raise notifications every 10 minutes
+  Short period for tests
   */
-  "SCHEDULER_ALIGNAK_ACTIVE": true,
-  "SCHEDULER_ALIGNAK_PERIOD": 600,
+  "SCHEDULER_ALIGNAK_ACTIVE": false,
+  "SCHEDULER_ALIGNAK_PERIOD": 10,
 
   /* As soon as a Graphite or Influx is existing in the backend, the received metrics are sent
   to the corresponding TSDB. If the TSDB is not available, metrics are stored internally


### PR DESCRIPTION
Using the jsmin library allow to parse and filter comments